### PR TITLE
Add folder for business/investment income imputation

### DIFF
--- a/puf_data/Biz_invest_income_imputation/placeholder
+++ b/puf_data/Biz_invest_income_imputation/placeholder
@@ -1,0 +1,1 @@
+Placeholder


### PR DESCRIPTION
This folder will contain a markdown file which summarizes the progress made on the imputation of E02000, E26270, P23250 and P22250 and the graphs and supporting files associated with it.